### PR TITLE
platform: add zephyr module support

### DIFF
--- a/heatshrink_decoder.h
+++ b/heatshrink_decoder.h
@@ -4,7 +4,12 @@
 #include <stdint.h>
 #include <stddef.h>
 #include "heatshrink_common.h"
+
+#if CONFIG_ZEPHYR_HEATSHRINK_MODULE
+#include "zephyr/heatshrink_config.h"
+#else
 #include "heatshrink_config.h"
+#endif
 
 typedef enum {
     HSDR_SINK_OK,               /* data sunk, ready to poll */

--- a/heatshrink_encoder.h
+++ b/heatshrink_encoder.h
@@ -4,7 +4,12 @@
 #include <stdint.h>
 #include <stddef.h>
 #include "heatshrink_common.h"
+
+#if CONFIG_ZEPHYR_HEATSHRINK_MODULE
+#include "zephyr/heatshrink_config.h"
+#else
 #include "heatshrink_config.h"
+#endif
 
 typedef enum {
     HSER_SINK_OK,               /* data sunk into input buffer */

--- a/zephyr/heatshrink_config.h
+++ b/zephyr/heatshrink_config.h
@@ -1,0 +1,31 @@
+#ifndef HEATSHRINK_CONFIG_H
+#define HEATSHRINK_CONFIG_H
+
+/* Should functionality assuming dynamic allocation be used? */
+#if defined(CONFIG_HEATSHRINK_DYNAMIC_ALLOC)
+#define HEATSHRINK_DYNAMIC_ALLOC 1
+#endif
+
+#if HEATSHRINK_DYNAMIC_ALLOC
+    /* Optional replacement of malloc/free */
+    #define HEATSHRINK_MALLOC(SZ) malloc(SZ)
+    #define HEATSHRINK_FREE(P, SZ) free(P)
+#else
+    /* Required parameters for static configuration */
+    #define HEATSHRINK_STATIC_INPUT_BUFFER_SIZE \
+        CONFIG_HEATSHRINK_STATIC_INPUT_BUFFER_SIZE
+    #define HEATSHRINK_STATIC_WINDOW_BITS       \
+        CONFIG_HEATSHRINK_STATIC_WINDOW_BITS
+    #define HEATSHRINK_STATIC_LOOKAHEAD_BITS    \
+        CONFIG_HEATSHRINK_STATIC_LOOKAHEAD_BITS
+#endif
+
+/* Turn on logging for debugging. */
+#define HEATSHRINK_DEBUGGING_LOGS 0
+
+/* Use indexing for faster compression. (This requires additional space.) */
+#if defined(CONFIG_HEATSHRINK_USE_INDEX)
+#define HEATSHRINK_USE_INDEX 1
+#endif
+
+#endif

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: heatshrink
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
Add support as external Zephyr module
Conservative initial build flow
Add customization using Kconfig
Issue #1

- Test dynamic allocation decoder: PASS
- Test static allocation decoder ws2: 8 lh2: 4 => PASS