### PR TITLE
feat: Make project standalone Zephyr module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 Kickmaker
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_HEATSHRINK)
+
+set(HEATSHRINK_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
+
+zephyr_library()
+zephyr_include_directories(${HEATSHRINK_DIR})
+
+zephyr_library_sources_ifdef(CONFIG_HEATSHRINK_DECODER
+  ${HEATSHRINK_DIR}/heatshrink_decoder.c
+)
+zephyr_library_sources_ifdef(CONFIG_HEATSHRINK_ENCODER
+  ${HEATSHRINK_DIR}/heatshrink_encoder.c
+)
+
+endif()

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,66 @@
+# Copyright (c) 2023 Kickmaker
+# SPDX-License-Identifier: Apache-2.0
+
+config ZEPHYR_HEATSHRINK_MODULE
+	bool
+
+config HEATSHRINK
+	bool "Heatshrink data compression"
+	help
+	  This option enables heatshrink compression library
+	  support.
+
+config HEATSHRINK_DYNAMIC_ALLOC
+	bool "Dynamic allocation support"
+	default n
+	help
+	  Use memory dynamic allocation.
+
+if !HEATSHRINK_DYNAMIC_ALLOC
+
+config HEATSHRINK_STATIC_INPUT_BUFFER_SIZE
+	int "Input buffer length"
+	default 32
+	help
+	  Determine input buffer to use for the decoder.
+
+config HEATSHRINK_STATIC_WINDOW_BITS
+	int "Window size"
+	default 8
+	range 4 15
+	help
+	  Determine how far back in the input can be searched for
+	  repeated pattern. Memory footprint is 2^(Window size).
+	  Ex.: Window size of 8 takes 2^8 (256) bytes.
+	  Compromise between resource usage vs compression efficiency.
+
+config HEATSHRINK_STATIC_LOOKAHEAD_BITS
+	int "Lookahead size"
+	default 4
+	range 3 14
+	help
+	  Determine the max length for repeated patterns that are found.
+	  Memory footprint is 2^(Lookahead size).
+	  Larger size means more complex pattern could be largely reduced.
+	  Compromise between resource usage vs compression efficiency.
+
+endif # !HEATSHRINK_DYNAMIC_ALLOC
+
+config HEATSHRINK_USE_INDEX
+	bool "Build index"
+	default n
+	help
+	  This option makes compression faster. It adds
+	  2^(Window size+1) + 512 bytes of RAM usage.
+
+config HEATSHRINK_DECODER
+	bool "Include decoder functions"
+	default y
+	help
+	  Enable decoder (decompression).
+
+config HEATSHRINK_ENCODER
+	bool "Include encoder functions"
+	default y
+	help
+	  Enable encoder (compression).

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,4 @@
 name: heatshrink
 build:
-  cmake-ext: True
-  kconfig-ext: True
+  cmake: .
+  kconfig: Kconfig


### PR DESCRIPTION
This solves the comment made here https://github.com/zephyrproject-rtos/zephyr/pull/61821#pullrequestreview-1594281591 in your PR for heatshrink into zephyr.

One can use it easily by putting into the project west.yml the following:
```
manifest:
  remotes:
    - ...
    - name: km
      url-base: https://github.com/tyalie # or https://github.com/kickmaker 

  projects:
    - ...
    - name: heatshrink
      remote: km
      revision: develop
      path: modules/lib/heatshrink
```