### PR TITLE
ci: fix: update docker image

### DIFF
--- a/.github/workflows/zephyr_build_test.yml
+++ b/.github/workflows/zephyr_build_test.yml
@@ -10,10 +10,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    container: ghcr.io/zephyrproject-rtos/ci:v0.26.2 
+    container: ghcr.io/zephyrproject-rtos/ci:v0.26.9
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
     steps:
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
 
       - name: Pull Zephyr last main revision
         run: |


### PR DESCRIPTION
- Fix zephyr requires an upper python3 version by upgrading docker image based environment to 0.27.5